### PR TITLE
ActiveModelSerializers version constraint is too loose

### DIFF
--- a/sinatra-active-model-serializers.gemspec
+++ b/sinatra-active-model-serializers.gemspec
@@ -51,5 +51,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sinatra', '~> 1.4'
   s.add_runtime_dependency 'sinatra-contrib', '>= 1.4.1'
   s.add_runtime_dependency 'sinatra-activerecord', '>= 2.0.0'
-  s.add_runtime_dependency 'active_model_serializers', '>= 0.9.0'
+  s.add_runtime_dependency 'active_model_serializers', '~> 0.9.0'
 end


### PR DESCRIPTION
The `0.10.x` series has a number of breaking changes form `0.9.x`